### PR TITLE
Update sqlite version and hashes

### DIFF
--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -67,8 +67,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://sqlite.org/2025/sqlite-autoconf-3490100.tar.gz",
-                    "sha256": "106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254",
+                    "url": "https://sqlite.org/2025/sqlite-autoconf-3500100.tar.gz",
+                    "sha256": "00a65114d697cfaa8fe0630281d76fd1b77afcd95cd5e40ec6a02cbbadbfea71",
                     "dest": "$APP/build/linux/x64/release/_deps/sqlite3-subbuild/sqlite3-populate-prefix/src"
                 },
                 {
@@ -76,8 +76,8 @@
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://sqlite.org/2025/sqlite-autoconf-3490100.tar.gz",
-                    "sha256": "106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254",
+                    "url": "https://sqlite.org/2025/sqlite-autoconf-3500100.tar.gz",
+                    "sha256": "00a65114d697cfaa8fe0630281d76fd1b77afcd95cd5e40ec6a02cbbadbfea71",
                     "dest": "$APP/build/linux/arm64/release/_deps/sqlite3-subbuild/sqlite3-populate-prefix/src"
                 },
                 {

--- a/foreign_deps/sqlite3_flutter_libs/CMakeLists.txt.patch
+++ b/foreign_deps/sqlite3_flutter_libs/CMakeLists.txt.patch
@@ -3,15 +3,15 @@
 @@ -14,12 +14,14 @@
    FetchContent_Declare(
      sqlite3
-     URL https://sqlite.org/2025/sqlite-autoconf-3490100.tar.gz
-+    URL_HASH SHA256=106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254
+     URL https://sqlite.org/2025/sqlite-autoconf-3500100.tar.gz
++    URL_HASH SHA256=00a65114d697cfaa8fe0630281d76fd1b77afcd95cd5e40ec6a02cbbadbfea71
      DOWNLOAD_EXTRACT_TIMESTAMP NEW
    )
  else()
    FetchContent_Declare(
      sqlite3
-     URL https://sqlite.org/2025/sqlite-autoconf-3490100.tar.gz
-+    URL_HASH SHA256=106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254
+     URL https://sqlite.org/2025/sqlite-autoconf-3500100.tar.gz
++    URL_HASH SHA256=00a65114d697cfaa8fe0630281d76fd1b77afcd95cd5e40ec6a02cbbadbfea71
    )
  endif()
  FetchContent_MakeAvailable(sqlite3)


### PR DESCRIPTION
This PR updates the hashes for sqlite 3.50.1.

I'm thinking how this process could be improved, specially if the app is not using the latest sqlite3_flutter_libs 