### PR TITLE
Add patches for sqlite3_flutter_libs 0.5.41

### DIFF
--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -166,6 +166,35 @@
                     }
                 ]
             }
+        },
+        "0.5.41": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "file",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://sqlite.org/2025/sqlite-autoconf-3510100.tar.gz",
+                        "sha256": "4f2445cd70479724d32ad015ec7fd37fbb6f6130013bd4bfbc80c32beb42b7e0",
+                        "dest": "$APP/build/linux/x64/release/_deps/sqlite3-subbuild/sqlite3-populate-prefix/src"
+                    },
+                    {
+                        "type": "file",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://sqlite.org/2025/sqlite-autoconf-3510100.tar.gz",
+                        "sha256": "4f2445cd70479724d32ad015ec7fd37fbb6f6130013bd4bfbc80c32beb42b7e0",
+                        "dest": "$APP/build/linux/arm64/release/_deps/sqlite3-subbuild/sqlite3-populate-prefix/src"
+                    },
+                    {
+                        "type": "patch",
+                        "path": "sqlite3_flutter_libs/0.5.41-CMakeLists.txt.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
         }
     },
     "super_native_extensions": {

--- a/foreign_deps/sqlite3_flutter_libs/0.5.41-CMakeLists.txt.patch
+++ b/foreign_deps/sqlite3_flutter_libs/0.5.41-CMakeLists.txt.patch
@@ -1,0 +1,17 @@
+--- a/linux/CMakeLists.txt      2025-05-25 16:58:31.000000000 +0200
++++ b/linux/CMakeLists.txt      2025-05-25 16:59:03.013600538 +0200
+@@ -14,12 +14,14 @@
+   FetchContent_Declare(
+     sqlite3
+     URL https://sqlite.org/2025/sqlite-autoconf-3510100.tar.gz
++    URL_HASH SHA256=4f2445cd70479724d32ad015ec7fd37fbb6f6130013bd4bfbc80c32beb42b7e0
+     DOWNLOAD_EXTRACT_TIMESTAMP NEW
+   )
+ else()
+   FetchContent_Declare(
+     sqlite3
+     URL https://sqlite.org/2025/sqlite-autoconf-3510100.tar.gz
++    URL_HASH SHA256=4f2445cd70479724d32ad015ec7fd37fbb6f6130013bd4bfbc80c32beb42b7e0
+   )
+ endif()
+ FetchContent_MakeAvailable(sqlite3)


### PR DESCRIPTION
Updated hashes for the new sqlite release.

BTW, I was reading the warning in https://pub.dev/packages/sqlite3_flutter_libs:

"This package relates to version 2.x of package:sqlite3, and is obsolete after upgrading. It will continue to be maintained until early 2026. See [notes on upgrading](https://github.com/simolus3/sqlite3.dart/blob/main/UPGRADING_TO_V3.md)."

Since that package uses hooks, the build and patch process is different.