### PR TITLE
fix: accept flutter url without `.git` suffix

### DIFF
--- a/flutter_app_fetcher/flutter_app_fetcher.py
+++ b/flutter_app_fetcher/flutter_app_fetcher.py
@@ -59,7 +59,7 @@ def fetch_repos(repos: list):
 def _search_submodules(gitmodules):
     def get_flutter_path():
         if ('url' in submodule and 'path' in submodule and
-                submodule['url'] == f'{FLUTTER_URL}.git'):
+                (submodule['url'] == FLUTTER_URL or submodule['url'] == f'{FLUTTER_URL}.git')):
             return submodule['path']
 
     with open(gitmodules, 'r') as input:


### PR DESCRIPTION
flatpak-flutter's submodule detection was working for one of my apps (Saber) but not another (Ricochlime).

Turns out it was because Saber used the `.git` suffix and Ricochlime didn't in its `.gitmodules` file:

```
[submodule "submodules/flutter"]
	path = submodules/flutter
	url = https://github.com/flutter/flutter   # without `.git` at the end
	branch = stable
```