### PR TITLE
Update pdfium binary for 0.2.0

### DIFF
--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -255,6 +255,30 @@
                     }
                 ]
             }
+        },
+        "0.2.3": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-x64.tgz",
+                        "sha256": "e76e0a37aefb843d56f04657475ce612157021b1ebc53d801f2fbfcc537ccf64",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/linux-x64/"
+                    },
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-arm64.tgz",
+                        "sha256": "1682079aae24d73fcfb4f1ae115dd7b661780ad31ad43c8804da2d518dc546e8",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/linux-arm64/"
+                    }
+                ]
+            }
         }
     },
     "printing": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -231,6 +231,30 @@
                     }
                 ]
             }
+        },
+        "0.2.2": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-x64.tgz",
+                        "sha256": "e76e0a37aefb843d56f04657475ce612157021b1ebc53d801f2fbfcc537ccf64",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/x64/"
+                    },
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-arm64.tgz",
+                        "sha256": "1682079aae24d73fcfb4f1ae115dd7b661780ad31ad43c8804da2d518dc546e8",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/arm64/"
+                    }
+                ]
+            }
         }
     },
     "printing": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -207,6 +207,30 @@
                     }
                 ]
             }
+        },
+        "0.2.1": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-x64.tgz",
+                        "sha256": "e76e0a37aefb843d56f04657475ce612157021b1ebc53d801f2fbfcc537ccf64",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/"
+                    },
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-arm64.tgz",
+                        "sha256": "1682079aae24d73fcfb4f1ae115dd7b661780ad31ad43c8804da2d518dc546e8",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/"
+                    }
+                ]
+            }
         }
     },
     "printing": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -153,7 +153,7 @@
         }
     },
     "pdfium_dart": {
-        "0.1.7": {
+        "0.1.2": {
             "manifest": {
                 "sources": [
                     {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -152,7 +152,7 @@
             }
         }
     },
-    "pdfium_flutter": {
+    "pdfium_dart": {
         "0.1.7": {
             "manifest": {
                 "sources": [
@@ -175,6 +175,35 @@
                         "sha256": "ee3998f311195bf9cecb3936b2ce3dd621e873277c36f1ca05de36f2646c07d4",
                         "dest": "$APP/build/linux/arm64/release/pdfium/chromium%2F7520/",
                         "strip-components": 0
+                    }
+                ]
+            }
+        },
+        "0.2.0": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "x86_64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-x64.tgz",
+                        "sha256": "e76e0a37aefb843d56f04657475ce612157021b1ebc53d801f2fbfcc537ccf64",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/"
+                    },
+                    {
+                        "type": "archive",
+                        "only-arches": [
+                            "aarch64"
+                        ],
+                        "url": "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium%2F7811/pdfium-linux-arm64.tgz",
+                        "sha256": "1682079aae24d73fcfb4f1ae115dd7b661780ad31ad43c8804da2d518dc546e8",
+                        "dest": "$APP/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/"
+                    },
+                    {
+                        "type": "patch",
+                        "path": "pdfium_dart/0.2.0-build.dart.patch",
+                        "dest": "$PUB_DEV"
                     }
                 ]
             }

--- a/foreign_deps/pdfium_dart/0.2.0-build.dart.patch
+++ b/foreign_deps/pdfium_dart/0.2.0-build.dart.patch
@@ -1,0 +1,14 @@
+--- a/hook/build.dart
++++ b/hook/build.dart
+@@ -14,7 +14,10 @@ void main(List<String> args) async {
+     if (input.config.code.targetOS == OS.iOS) return;
+ 
+     final target = _PdfiumTarget.fromCodeConfig(input.config.code);
+-    final outputFile = input.outputDirectory.resolve(target.libraryFileName);
++    final outputSubdir = _pdfiumRelease.replaceAll('%2F', '_');
++    final outputFile = input.outputDirectoryShared.resolve(
++      '$outputSubdir/${target.libraryFileName}',
++    );
+ 
+     await _downloadPdfium(
+       outputFile: outputFile,


### PR DESCRIPTION

This change is required for apps to build with `pdfium_flutter: ^0.2.0`.

I've included a patch to use a reproducible location for the shared library. It has been upstreamed in https://github.com/espresso3389/pdfrx/pull/638 and thus isn't included in future versions (>=0.2.1).