### PR TITLE
Add foreign dep for dart_lmdb2 and flutter_lmdb2

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Perform a verbose build to further investigate the failure.
 ### Deal with Foreign Dependencies
 Some Dart packages, coming from pub.dev, are wrappers around C/C++ or Rust code. The build process of such a dependency can still try to download a resource. This behavior cannot be known upfront based on the `pubspec.lock` file. If the verbose build log shows a download attempt, then this download has to be added to the `sources` in the manifest. For Rust dependencies, that make use of cargo, the `Cargo.lock` file can be specified with the `--cargo-locks` command line option, or with a [foreign.json](#foreign-code) file.
 
-Known foreign dependencies are described in the `foreign-deps/foreign-deps.json` file, these are automatically handled by flatpak-flutter. In the case of Rust dependencies a `rustup-<version>.json` module is generated, providing a recent toolchain. If a specific version is required then this can be done by specifying the module in the `flatpak-flutter.yml` file.
+Known foreign dependencies are described in the `foreign-deps/foreign-deps.json` file, these are automatically handled by flatpak-flutter. In the case of Rust dependencies a `rustup-<version>.json` module is generated, providing a recent toolchain. If a specific version is required then this can be done by specifying the module in the `flatpak-flutter.yml` file. Maintainer notes for individual entries (patch rationale, license compatibility) are in [`foreign_deps/README.md`](foreign_deps/README.md).
 
 ### Report an Issue
 If build issues remain then [an issues](https://github.com/TheAppgineer/flatpak-flutter/issues) can be opened.

--- a/foreign_deps/README.md
+++ b/foreign_deps/README.md
@@ -33,7 +33,7 @@ fails with a plain `FileSystemException` instead of crashing; after copying
 `liblmdb.so` into `bundle/lib/` (what `flutter_lmdb2`'s Linux support, below, does
 automatically), the app opened a real LMDB store successfully.
 
-This is a genuine bug in `dart_lmdb2` itself, reported to
+This is a genuine bug in `dart_lmdb2` itself, worth reporting to
 [grammatek/dart_lmdb2](https://github.com/grammatek/dart_lmdb2) — this entry should be
 retired once fixed there.
 
@@ -81,6 +81,6 @@ prebuilt `objectbox-c` archive), LMDB is compiled from its own real source here 
 avoiding a repeat of the licensing complication a prebuilt, no-source binary can create
 for GPL-licensed apps.
 
-Like `dart_lmdb2` above, this is a genuine, reportable gap, reported to
+Like `dart_lmdb2` above, this is a genuine, reportable gap — worth raising with
 [grammatek/dart_lmdb2](https://github.com/grammatek/dart_lmdb2) — this entry should be
 retired once fixed there.

--- a/foreign_deps/README.md
+++ b/foreign_deps/README.md
@@ -1,0 +1,86 @@
+# Foreign dependencies — maintainer notes
+
+## dart_lmdb2
+
+`dart_lmdb2`'s `LMDBNative._resolveLibraryPath()` (`lib/src/lmdb_native.dart`) locates
+`liblmdb.so`/`.dylib`/`.dll` at runtime via `Isolate.resolvePackageUriSync()` on a
+`package:dart_lmdb2/...` URI. That API is backed by `.dart_tool/package_config.json` —
+a dev-time artifact that only exists next to a JIT run (`dart run`/`flutter run`), not
+inside a compiled AOT release build.
+
+**Confirmed empirically, not just reasoned through:** built a scratch Flutter Linux app
+depending on `dart_lmdb2`, ran `flutter build linux --release`, copied only
+`build/linux/x64/release/bundle/` to an isolated directory (no source project, no
+pub-cache — the same shape a Flatpak install has), and ran the binary. It crashed
+immediately on the first `LMDB()` construction:
+
+```
+Unsupported operation: Isolate.resolvePackageUriSync
+#1  LMDBNative._resolveLibraryPath (package:dart_lmdb2/src/lmdb_native.dart:89)
+```
+
+This isn't Flatpak-specific — it breaks every compiled Flutter Linux/Windows release
+build using `dart_lmdb2`, regardless of how `liblmdb.so` itself was obtained (downloaded
+via `fetch_native` or compiled from the vendored `mdb.c`/`midl.c` via `dart run
+dart_lmdb2:build`). The patch (`dart_lmdb2/0.9.12-lmdb_native.dart.patch`) tries
+`Isolate.resolvePackageUriSync()` first (unchanged dev-time behaviour), then falls back
+to a path next to the running executable (`<exe_dir>/lib/<libName>`, matching Flutter's
+own native-library bundling convention, confirmed in the same probe:
+`build/linux/x64/release/bundle/lib/libapp.so` sits right there) on `UnsupportedError`.
+
+Re-verified after patching, same probe methodology: without `liblmdb.so` present it now
+fails with a plain `FileSystemException` instead of crashing; after copying
+`liblmdb.so` into `bundle/lib/` (what `flutter_lmdb2`'s Linux support, below, does
+automatically), the app opened a real LMDB store successfully.
+
+This is a genuine bug in `dart_lmdb2` itself, reported to
+[grammatek/dart_lmdb2](https://github.com/grammatek/dart_lmdb2) — this entry should be
+retired once fixed there.
+
+## flutter_lmdb2
+
+`flutter_lmdb2` (the Flutter-plugin wrapper around `dart_lmdb2`, bundling the native
+LMDB library into a shipped app) has no Linux (or Windows) support at all as published:
+both platforms are commented out in its own `pubspec.yaml`, and there is no `linux/`
+directory in the package. Without this, Flutter's plugin-discovery tooling never
+touches `dart_lmdb2`'s native library for a Linux build — nothing bundles `liblmdb.so`
+into the app at all, regardless of the `dart_lmdb2` fix above.
+
+Two patches, applied together:
+
+- **`flutter_lmdb2/0.9.5-linux-plugin-files.patch`** adds a `linux/` platform directory:
+  a minimal no-op GObject plugin (same shape as every other no-op Linux Flutter plugin;
+  all real work happens through `dart_lmdb2`'s Dart FFI, not a method channel) and a
+  `linux/CMakeLists.txt` that **compiles `liblmdb.so` from source** — `mdb.c`/`midl.c`
+  from `LMDB/lmdb.git` at tag `LMDB_0.9.31`, pinned by both tag and commit hash in
+  `foreign_deps.json`, fetched via a plain `git` source rather than a prebuilt-binary
+  download — and registers the result via the `flutter_lmdb2_bundled_libraries`
+  `PARENT_SCOPE` variable, the same convention `objectbox_flutter_libs`'s own
+  `linux/CMakeLists.txt` uses to get Flutter's build to copy a library into
+  `build/linux/<arch>/release/bundle/lib/`. Also links `Threads::Threads`
+  (`find_package(Threads REQUIRED)`) explicitly against the new `lmdb_native` target —
+  `mdb.c` uses `pthread_mutex`/pthread-specific data, and while glibc ≥ 2.34 merges
+  pthread into `libc.so.6` (making this a no-op on the machine this was developed on,
+  confirmed via `ldd -r` showing zero undefined symbols either way), relying on that
+  instead of linking explicitly isn't portable to older glibc or non-glibc runtimes.
+
+- **`flutter_lmdb2/0.9.5-pubspec.yaml.patch`** uncomments the `linux:` plugin platform
+  block so Flutter's tooling actually picks up the new `linux/` directory.
+
+**Verified empirically, full pipeline:** applied both patches plus the `dart_lmdb2`
+patch above, cloned the pinned LMDB tag into `linux/lmdb-src`, built a scratch Flutter
+app depending on `flutter_lmdb2`, and ran `flutter build linux --release`:
+`build/linux/x64/release/bundle/lib/` contained `liblmdb.so` right next to `libapp.so`,
+with zero undefined symbols (`ldd -r`); `.flutter-plugins-dependencies` listed
+`flutter_lmdb2` under `"linux"` with `"native_build": true`; copied only `bundle/` to
+an isolated directory (no source project, no pub-cache) and ran the binary — `LMDB`
+opened successfully. Zero network access, zero prebuilt binaries, at any step.
+
+Unlike `objectbox_flutter_libs`'s own `linux/CMakeLists.txt` (which `FetchContent`s a
+prebuilt `objectbox-c` archive), LMDB is compiled from its own real source here —
+avoiding a repeat of the licensing complication a prebuilt, no-source binary can create
+for GPL-licensed apps.
+
+Like `dart_lmdb2` above, this is a genuine, reportable gap, reported to
+[grammatek/dart_lmdb2](https://github.com/grammatek/dart_lmdb2) — this entry should be
+retired once fixed there.

--- a/foreign_deps/dart_lmdb2/0.9.12-lmdb_native.dart.patch
+++ b/foreign_deps/dart_lmdb2/0.9.12-lmdb_native.dart.patch
@@ -1,0 +1,55 @@
+--- a/lib/src/lmdb_native.dart	2026-07-06 15:20:59.118543060 +0300
++++ b/lib/src/lmdb_native.dart	2026-07-06 15:20:59.119518905 +0300
+@@ -1,6 +1,7 @@
+ import 'dart:ffi' show Abi, DynamicLibrary;
+ import 'dart:io';
+ import 'dart:isolate';
++import 'package:path/path.dart' as p;
+ import 'generated_bindings.dart';
+ 
+ /// Singleton for managing LMDB native library access
+@@ -84,13 +85,37 @@
+             ? 'liblmdb.dylib'
+             : 'liblmdb.so';
+ 
+-    final Uri packageUri =
+-        Uri.parse('package:dart_lmdb2/src/native/$platform/$libName');
+-    final Uri? fileUri = Isolate.resolvePackageUriSync(packageUri);
+-
+-    if (fileUri == null) {
+-      throw FileSystemException('Could not resolve native library path');
++    // `package:` URI resolution (Isolate.resolvePackageUriSync) only works
++    // in JIT mode (`dart run`/`flutter run`), backed by
++    // .dart_tool/package_config.json — a dev-time artifact not present in a
++    // compiled AOT release build. There it throws UnsupportedError outright
++    // rather than just failing to resolve. Try it first (keeps working
++    // exactly as before for dev-time use), then fall back to a path next to
++    // the running executable, matching where Flutter's own native-library
++    // bundling convention places plugin libraries
++    // (e.g. build/linux/x64/release/bundle/lib/*.so).
++    try {
++      final Uri? fileUri = Isolate.resolvePackageUriSync(
++          Uri.parse('package:dart_lmdb2/src/native/$platform/$libName'));
++      if (fileUri != null) {
++        final path = fileUri.toFilePath();
++        if (File(path).existsSync()) return path;
++      }
++    } on UnsupportedError {
++      // AOT/release build — expected here, fall through below.
+     }
+-    return fileUri.toFilePath();
++
++    final exeDir = File(Platform.resolvedExecutable).parent.path;
++    final candidates = [
++      p.join(exeDir, 'lib', libName),
++      p.join(exeDir, libName),
++    ];
++    for (final candidate in candidates) {
++      if (File(candidate).existsSync()) return candidate;
++    }
++
++    throw FileSystemException(
++        'Could not resolve native library path (tried package: URI and '
++        '${candidates.join(", ")})');
+   }
+ }

--- a/foreign_deps/flutter_lmdb2/0.9.5-linux-plugin-files.patch
+++ b/foreign_deps/flutter_lmdb2/0.9.5-linux-plugin-files.patch
@@ -1,0 +1,163 @@
+diff --git a/linux/CMakeLists.txt b/linux/CMakeLists.txt
+new file mode 100644
+index 0000000..eacd4fb
+--- /dev/null
++++ b/linux/CMakeLists.txt
+@@ -0,0 +1,83 @@
++# The Flutter tooling requires that developers have CMake 3.10 or later
++# installed. You should not increase this version, as doing so will cause
++# the plugin to fail to compile for some customers of the plugin.
++cmake_minimum_required(VERSION 3.10)
++
++# Project-level configuration.
++set(PROJECT_NAME "flutter_lmdb2")
++project(${PROJECT_NAME} LANGUAGES C CXX)
++
++# This value is used when generating builds using this plugin, so it must
++# not be changed.
++set(PLUGIN_NAME "flutter_lmdb2_plugin")
++
++# Any new source files that you add to the plugin should be added here.
++list(APPEND PLUGIN_SOURCES
++  "flutter_lmdb2_plugin.cc"
++)
++
++# Define the plugin library target. Its name must not be changed (see comment
++# on PLUGIN_NAME above).
++add_library(${PLUGIN_NAME} SHARED
++  ${PLUGIN_SOURCES}
++)
++
++# Apply a standard set of build settings that are configured in the
++# application-level CMakeLists.txt. This can be removed for plugins that want
++# full control over build settings.
++apply_standard_settings(${PLUGIN_NAME})
++
++# Symbols are hidden by default to reduce the chance of accidental conflicts
++# between plugins. This should not be removed; any symbols that should be
++# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
++set_target_properties(${PLUGIN_NAME} PROPERTIES
++  CXX_VISIBILITY_PRESET hidden)
++target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
++
++# Source include directories and library dependencies. Add any plugin-specific
++# dependencies here.
++target_include_directories(${PLUGIN_NAME} INTERFACE
++  "${CMAKE_CURRENT_SOURCE_DIR}/include")
++target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
++target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
++
++# ----------------------------------------------------------------------
++# Build liblmdb from source — no FetchContent/network download here. LMDB's
++# own source (LMDB/lmdb.git, tag LMDB_0.9.31 — the same commit ob-dump's own
++# C++ core builds and has verified) is expected to already exist at
++# ./lmdb-src, populated offline before this CMake configure step runs (see
++# the "git" source in this plugin's foreign_deps.json entry). Deliberately
++# not a prebuilt binary download (c.f. objectbox_flutter_libs's own
++# linux/CMakeLists.txt, which does FetchContent a prebuilt objectbox-c
++# archive) — see docs/BACKLOG.md ToMany/Flex-style reasoning in the parent
++# ob-dump project for why this project avoids that pattern.
++
++set(LMDB_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lmdb-src/libraries/liblmdb")
++
++add_library(lmdb_native SHARED
++  "${LMDB_SRC_DIR}/mdb.c"
++  "${LMDB_SRC_DIR}/midl.c"
++)
++set_target_properties(lmdb_native PROPERTIES
++  OUTPUT_NAME "lmdb"
++)
++
++# mdb.c uses pthread_mutex/pthread_key (thread-specific data + mutexes) —
++# link explicitly rather than relying on it being pulled in transitively by
++# something else in the process (Threads::Threads is the portable way to
++# get -lpthread/-pthread regardless of platform threading model).
++find_package(Threads REQUIRED)
++target_link_libraries(lmdb_native PRIVATE Threads::Threads)
++
++# ----------------------------------------------------------------------
++
++# List of absolute paths to libraries that should be bundled with the
++# application build. Flutter's Linux build copies these into
++# build/linux/<arch>/release/bundle/lib/ — the executable-relative location
++# dart_lmdb2's own patched LMDBNative._resolveLibraryPath looks in once
++# Isolate.resolvePackageUriSync is unavailable (a compiled AOT release
++# build) — see the sibling dart_lmdb2 foreign_deps entry for that fix.
++set(flutter_lmdb2_bundled_libraries
++  "$<TARGET_FILE:lmdb_native>"
++  PARENT_SCOPE
++)
+diff --git a/linux/flutter_lmdb2_plugin.cc b/linux/flutter_lmdb2_plugin.cc
+new file mode 100644
+index 0000000..daaa40f
+--- /dev/null
++++ b/linux/flutter_lmdb2_plugin.cc
+@@ -0,0 +1,36 @@
++#include "include/flutter_lmdb2/flutter_lmdb2_plugin.h"
++
++#include <flutter_linux/flutter_linux.h>
++
++#define FLUTTER_LMDB2_PLUGIN(obj) \
++  (G_TYPE_CHECK_INSTANCE_CAST((obj), flutter_lmdb2_plugin_get_type(), \
++                              FlutterLmdb2Plugin))
++
++// This plugin has no platform-channel surface of its own — its only job is
++// to be present in the resolved dependency graph so Flutter's Linux
++// plugin-discovery/build tooling picks up this directory's CMakeLists.txt
++// (which builds liblmdb.so from source and bundles it into
++// build/linux/<arch>/release/bundle/lib/). Same shape as the Android/iOS/
++// macOS FlutterLmdb2Plugin classes, which are equally no-op — all real work
++// happens in dart_lmdb2's Dart FFI bindings, not through a method channel.
++struct _FlutterLmdb2Plugin {
++  GObject parent_instance;
++};
++
++G_DEFINE_TYPE(FlutterLmdb2Plugin, flutter_lmdb2_plugin, g_object_get_type())
++
++static void flutter_lmdb2_plugin_dispose(GObject* object) {
++  G_OBJECT_CLASS(flutter_lmdb2_plugin_parent_class)->dispose(object);
++}
++
++static void flutter_lmdb2_plugin_class_init(FlutterLmdb2PluginClass* klass) {
++  G_OBJECT_CLASS(klass)->dispose = flutter_lmdb2_plugin_dispose;
++}
++
++static void flutter_lmdb2_plugin_init(FlutterLmdb2Plugin* self) {}
++
++void flutter_lmdb2_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
++  FlutterLmdb2Plugin* plugin = FLUTTER_LMDB2_PLUGIN(
++      g_object_new(flutter_lmdb2_plugin_get_type(), nullptr));
++  g_object_unref(plugin);
++}
+diff --git a/linux/include/flutter_lmdb2/flutter_lmdb2_plugin.h b/linux/include/flutter_lmdb2/flutter_lmdb2_plugin.h
+new file mode 100644
+index 0000000..43e98ee
+--- /dev/null
++++ b/linux/include/flutter_lmdb2/flutter_lmdb2_plugin.h
+@@ -0,0 +1,26 @@
++#ifndef FLUTTER_PLUGIN_FLUTTER_LMDB2_PLUGIN_H_
++#define FLUTTER_PLUGIN_FLUTTER_LMDB2_PLUGIN_H_
++
++#include <flutter_linux/flutter_linux.h>
++
++G_BEGIN_DECLS
++
++#ifdef FLUTTER_PLUGIN_IMPL
++#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
++#else
++#define FLUTTER_PLUGIN_EXPORT
++#endif
++
++typedef struct _FlutterLmdb2Plugin FlutterLmdb2Plugin;
++typedef struct {
++  GObjectClass parent_class;
++} FlutterLmdb2PluginClass;
++
++FLUTTER_PLUGIN_EXPORT GType flutter_lmdb2_plugin_get_type();
++
++FLUTTER_PLUGIN_EXPORT void flutter_lmdb2_plugin_register_with_registrar(
++    FlPluginRegistrar* registrar);
++
++G_END_DECLS
++
++#endif  // FLUTTER_PLUGIN_FLUTTER_LMDB2_PLUGIN_H_

--- a/foreign_deps/flutter_lmdb2/0.9.5-pubspec.yaml.patch
+++ b/foreign_deps/flutter_lmdb2/0.9.5-pubspec.yaml.patch
@@ -1,0 +1,12 @@
+--- a/pubspec.yaml	2026-07-06 15:31:52.798970106 +0300
++++ b/pubspec.yaml	2026-07-06 15:31:52.800242857 +0300
+@@ -36,7 +36,7 @@
+         mainClass: FlutterLmdb2Plugin
+       macos:
+         pluginClass: FlutterLmdb2Plugin
+-#      linux:
+-#        pluginClass: FlutterLmdb2Plugin
++      linux:
++        pluginClass: FlutterLmdb2Plugin
+ #      windows:
+ #        pluginClass: FlutterLmdb2Plugin

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -13,6 +13,19 @@
             }
         }
     },
+    "dart_lmdb2": {
+        "0.9.12": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "patch",
+                        "path": "dart_lmdb2/0.9.12-lmdb_native.dart.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
+        }
+    },
     "flutter_discord_rpc": {
         "1.0.0": {
             "cargo_locks": [
@@ -27,6 +40,31 @@
                         "type": "patch",
                         "path": "cargokit/run_build_tool.sh.patch",
                         "dest": "$PUB_DEV/cargokit"
+                    }
+                ]
+            }
+        }
+    },
+    "flutter_lmdb2": {
+        "0.9.5": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "git",
+                        "url": "https://github.com/LMDB/lmdb.git",
+                        "tag": "LMDB_0.9.31",
+                        "commit": "ce201088de95d26fc0da36ba805bf2ddc2ba74ff",
+                        "dest": "$PUB_DEV/linux/lmdb-src"
+                    },
+                    {
+                        "type": "patch",
+                        "path": "flutter_lmdb2/0.9.5-linux-plugin-files.patch",
+                        "dest": "$PUB_DEV"
+                    },
+                    {
+                        "type": "patch",
+                        "path": "flutter_lmdb2/0.9.5-pubspec.yaml.patch",
+                        "dest": "$PUB_DEV"
                     }
                 ]
             }


### PR DESCRIPTION
## What

Adds `dart_lmdb2` (0.9.12) and `flutter_lmdb2` (0.9.5) to `foreign_deps.json`.

- `dart_lmdb2`: patches a runtime crash in compiled release builds (not a Flatpak-specific issue - affects every consumer).
- `flutter_lmdb2`: adds Linux platform support, which the published package has none of at all.

## How

### dart_lmdb2 - `Isolate.resolvePackageUriSync` crash in AOT builds

`LMDBNative._resolveLibraryPath()` (`lib/src/lmdb_native.dart`) locates the native LMDB
library on Linux/Windows via `Isolate.resolvePackageUriSync()` on a
`package:dart_lmdb2/...` URI. That API is backed by `.dart_tool/package_config.json` - a
dev-time artifact present next to a JIT run (`dart run`/`flutter run`), not inside a
compiled AOT release build.

Confirmed empirically: built a scratch Flutter Linux app depending on `dart_lmdb2`, ran
`flutter build linux --release`, copied only `build/linux/x64/release/bundle/` to an
isolated directory (no source project, no pub-cache - the same shape a Flatpak install
has), and ran the binary. It crashed immediately on the first `LMDB()` construction:

```
Unsupported operation: Isolate.resolvePackageUriSync
#1  LMDBNative._resolveLibraryPath (package:dart_lmdb2/src/lmdb_native.dart:89)
```

The patch tries `Isolate.resolvePackageUriSync()` first (unchanged dev-time behaviour),
then falls back to a path next to the running executable
(`<exe_dir>/lib/<libName>`, then `<exe_dir>/<libName>`) on `UnsupportedError` - matching
where Flutter's own native-library bundling convention already places plugin libraries
(confirmed in the same probe: `bundle/lib/libapp.so` sits right there).

### flutter_lmdb2 - no Linux (or Windows) support at all

`flutter_lmdb2`'s own `pubspec.yaml` has both platforms commented out, and there is no
`linux/` directory in the package. Without it, Flutter's plugin-discovery tooling never
touches `dart_lmdb2`'s native library for a Linux build - nothing bundles `liblmdb.so`
into the app, regardless of the `dart_lmdb2` fix above.

Two patches, applied together:

- **`linux-plugin-files.patch`** adds a `linux/` platform directory: a minimal no-op
  GObject plugin (same shape as every other no-op Linux Flutter plugin - all real work
  happens through `dart_lmdb2`'s Dart FFI, not a method channel) and a
  `linux/CMakeLists.txt` that **compiles `liblmdb.so` from source** - `mdb.c`/`midl.c`
  from `LMDB/lmdb.git` at tag `LMDB_0.9.31` (pinned by both tag and commit hash), fetched
  via a plain `git` source rather than a prebuilt-binary download - and registers the
  result via the `flutter_lmdb2_bundled_libraries` `PARENT_SCOPE` variable, the same
  convention `objectbox_flutter_libs`'s own `linux/CMakeLists.txt` uses to get Flutter's
  build to copy a library into `build/linux/<arch>/release/bundle/lib/`. Also links
  `Threads::Threads` (`find_package(Threads REQUIRED)`) explicitly - `mdb.c` uses
  `pthread_mutex`/pthread-specific data, and relying on it being pulled in transitively
  isn't portable across glibc versions/runtimes even though it happened to be a no-op on
  the development machine (glibc ≥ 2.34 merges pthread into `libc.so.6`).
- **`pubspec.yaml.patch`** uncomments the `linux:` plugin platform block so Flutter's
  tooling actually picks up the new `linux/` directory.

### Why a `git` source instead of a prebuilt archive

Unlike `objectbox_flutter_libs`'s own `linux/CMakeLists.txt` (which `FetchContent`s a
prebuilt `objectbox-c` archive - no source available, a real licensing complication for
GPL-3.0 apps per that entry's own notes), LMDB is compiled from its own real source here.
No prebuilt-binary licensing question to worry about for any app license.

## Upstream

Both are genuine bugs/gaps in `dart_lmdb2`/`flutter_lmdb2` themselves (not Flatpak- or
this-project-specific) - worth reporting to
[grammatek/dart_lmdb2](https://github.com/grammatek/dart_lmdb2). Both entries should be
retired once fixed there.

## Test plan

- [x] Built a scratch Flutter Linux app depending on `dart_lmdb2` directly, confirmed
      the `Isolate.resolvePackageUriSync` crash in an isolated release-bundle copy
      (unpatched), then confirmed the patched version fails cleanly instead of crashing
      when `liblmdb.so` isn't present, and succeeds once it is.
- [x] Built a second scratch Flutter Linux app depending on `flutter_lmdb2`, applied all
      three patches plus cloned the pinned `LMDB_0.9.31` tag into `linux/lmdb-src`, ran
      `flutter build linux --release`.
- [x] Confirmed `build/linux/x64/release/bundle/lib/liblmdb.so` was compiled and
      bundled next to `libapp.so`/`libflutter_lmdb2_plugin.so`, with zero undefined
      symbols (`ldd -r`).
- [x] Confirmed `.flutter-plugins-dependencies` lists `flutter_lmdb2` under `"linux"`
      with `"native_build": true`.
- [x] Copied only `bundle/` to an isolated directory (no source project, no pub-cache)
      and ran the binary - `LMDB` opened a real store successfully. Zero network
      access, zero prebuilt binaries, at any step in the full pipeline.
- [x] Verified both patch files apply cleanly with plain `patch -p1` against a fresh,
      unpatched copy of each package from the pub cache.