### PR TITLE
Fix builds with super_native_extensions 0.10.0

### DIFF
--- a/flatpak-flutter.py
+++ b/flatpak-flutter.py
@@ -187,8 +187,12 @@ def _create_pub_cache(build_path_app: str, sdk_path: str, pubspec_path: str):
         exit(1)
 
 
-def _handle_foreign_dependencies(app: str, build_path_app: str, foreign_deps_path: str, manifest_root: str):
-    abs_path = f'{os.getcwd()}/{build_path_app}'
+def _handle_foreign_dependencies(build_path_app: str, app_pubspec: str, sdk_path: str, foreign_deps_path: str, manifest_root: str):
+    flutter_tools = f'{sdk_path}/packages/flutter_tools'
+    pubspec_paths = [
+        f'{build_path_app}/{app_pubspec}/pubspec.lock',
+        f'{build_path_app}/{flutter_tools}/pubspec.lock',
+    ]
     extra_pubspecs = []
     cargo_locks = []
     sources = []
@@ -218,7 +222,7 @@ def _handle_foreign_dependencies(app: str, build_path_app: str, foreign_deps_pat
 
                 if 'dest' in source:
                     dest = str(source['dest']).replace('$PUB_DEV', pub_dev)
-                    dest = dest.replace('$APP', app)
+                    dest = dest.replace('$APP', app_pubspec)
                     source['dest'] = dest
 
                 sources.append(source)
@@ -231,15 +235,18 @@ def _handle_foreign_dependencies(app: str, build_path_app: str, foreign_deps_pat
             for dependency in foreign.values():
                 append_dependency(dependency)
 
-    with open(f'{foreign_deps_path}/foreign_deps.json', 'r') as foreign_deps, open(f'{abs_path}/pubspec.lock') as deps:
-        foreign_deps = json.load(foreign_deps)
-        deps = yaml.full_load(deps)
+    deps = {}
+    for pubspec_path in pubspec_paths:
+        with open(pubspec_path) as pubspec_lock:
+            deps.update(yaml.full_load(pubspec_lock)['packages'])
 
+    with open(f'{foreign_deps_path}/foreign_deps.json') as foreign_deps:
+        foreign_deps = json.load(foreign_deps)
         for name in foreign_deps.keys():
-            if name not in local_deps and name in deps['packages']:
+            if name not in local_deps and name in deps:
                 foreign_dep = foreign_deps[name]
                 foreign_dep_versions = list(foreign_dep.keys())
-                dep = deps['packages'][name]
+                dep = deps[name]
                 dep_version = dep['version']
 
                 for foreign_dep_version in reversed(foreign_dep_versions):
@@ -437,10 +444,10 @@ def main():
 
         print(f'SDK path: {sdk_path}, tag: {tag}')
     
-        full_pubspec_path = f'{build_path_app}/{app_pubspec}'
         extra_pubspecs, cargo_locks, foreign = _handle_foreign_dependencies(
+            build_path_app,
             app_pubspec,
-            full_pubspec_path,
+            sdk_path,
             foreign_deps_path,
             manifest_root,
         )

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -105,6 +105,19 @@
             }
         }
     },
+    "hooks_runner": {
+        "1.1.1": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "patch",
+                        "path": "hooks_runner/1.1.1-build_runner.dart.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
+        }
+    },
     "media_kit_libs_linux": {
         "1.2.1": {
             "manifest": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -116,6 +116,17 @@
                     }
                 ]
             }
+        },
+        "1.5.0": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "patch",
+                        "path": "hooks_runner/1.5.0-build_runner.dart.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
         }
     },
     "media_kit_libs_linux": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -152,6 +152,19 @@
             }
         }
     },
+    "native_toolchain_rust": {
+        "1.0.4": {
+            "manifest": {
+                "sources": [
+                    {
+                        "type": "patch",
+                        "path": "native_toolchain_rust/build_runner.dart.patch",
+                        "dest": "$PUB_DEV"
+                    }
+                ]
+            }
+        }
+    },
     "pdfium_dart": {
         "0.1.2": {
             "manifest": {

--- a/foreign_deps/foreign_deps.json
+++ b/foreign_deps/foreign_deps.json
@@ -77,8 +77,8 @@
             }
         }
     },
-    "flutter_webrtc" : {
-        "1.3.0" : {
+    "flutter_webrtc": {
+        "1.3.0": {
             "manifest": {
                 "sources": [
                     {
@@ -683,6 +683,11 @@
                     }
                 ]
             }
+        },
+        "0.10.0-dev.1": {
+            "cargo_locks": [
+                "$PUB_DEV/rust"
+            ]
         }
     }
 }

--- a/foreign_deps/hooks_runner/1.1.1-build_runner.dart.patch
+++ b/foreign_deps/hooks_runner/1.1.1-build_runner.dart.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/src/build_runner/build_runner.dart b/lib/src/build_runner/build_runner.dart
+index 1370869d..ca282444 100644
+--- a/lib/src/build_runner/build_runner.dart
++++ b/lib/src/build_runner/build_runner.dart
+@@ -614,8 +614,10 @@ class NativeAssetsBuildRunner {
+       ..._httpProxyEnvironmentVariables,
+     };
+     const variablePrefixesFilter = {
++      'CARGO_', // Needed for the Rust package manager.
+       'CCACHE_', // Needed for Ccache.
+       'NIX_', // Needed for Nix-installed toolchains.
++      'RUSTUP_', // Needed for the Rust toolchain installer.
+     };
+ 
+     return staticVariablesFilter.contains(environmentVariableName) ||

--- a/foreign_deps/hooks_runner/1.5.0-build_runner.dart.patch
+++ b/foreign_deps/hooks_runner/1.5.0-build_runner.dart.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/src/build_runner/build_runner.dart b/lib/src/build_runner/build_runner.dart
+index 5c9b645f..79671ac5 100644
+--- a/lib/src/build_runner/build_runner.dart
++++ b/lib/src/build_runner/build_runner.dart
+@@ -627,11 +627,13 @@ class NativeAssetsBuildRunner {
+     };
+ 
+     const variablePrefixesFilter = {
++      'CARGO_', // Needed for the Rust package manager.
+       'CCACHE_', // Needed for Ccache.
+       'DOTNET_', // Needed for .Net.
+       'NIX_', // Needed for Nix-installed toolchains.
+       'NUGET_', // Needed for NuGet.
+       'CONAN_', // Needed for Conan Package Manager.
++      'RUSTUP_', // Needed for the Rust toolchain installer.
+     };
+ 
+     return staticVariablesFilter.contains(environmentVariableName) ||

--- a/foreign_deps/native_toolchain_rust/build_runner.dart.patch
+++ b/foreign_deps/native_toolchain_rust/build_runner.dart.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/src/build_runner.dart b/lib/src/build_runner.dart
+index ea548d4..d87efcc 100644
+--- a/lib/src/build_runner.dart
++++ b/lib/src/build_runner.dart
+@@ -79,7 +79,4 @@ interface class RustBuildRunner {
+     );
+ 
+-    logger.info('Ensuring $toolchainChannel is installed');
+-    await ensureToolchainDownloaded(crateDirectory.path);
+-
+     logger.info('Running cargo build');
+     await processRunner.invokeRustup(


### PR DESCRIPTION

- Fixes #125 
- Needed for my app in https://github.com/flathub/com.adilhanney.saber/pull/206

Summary of changes:
- Removed cargokit patch from super_native_extensions 0.10.0
- Removed rustup update check
- Allowed CARGO_HOME and RUSTUP_HOME vars through the build hook whitelist
  (submitted upstream in https://github.com/dart-lang/native/pull/3545)
- Tweaked `_handle_foreign_dependencies` to run on flutter_tools' pubspec.lock too, needed for the build hook patch